### PR TITLE
Increase default timeout significantly

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ it is not needed for public repositories however.
 Options:
   -r, --remote   The remote from which the Pull Request is applied.     [default: "origin"]
   -b, --branch   The branch where the Pull Request will be applied to.  [default: the current branch]
-  -t, --timeout  Time limit for fetching the pull request patch.        [default: 5000]
+  -t, --timeout  Time limit for fetching the pull request patch.        [default: 30000]
 ```
 
 Example:

--- a/src/init.js
+++ b/src/init.js
@@ -1,4 +1,4 @@
-var TIMEOUT = 5000;
+var TIMEOUT = 30000;
 var amArgs = [];
 var args = require("optimist")
     .usage("Apply pull/merge requests.\nUsage: apply-pr [OPTIONS] pull-request-id [--] [git am OPTIONS]\n\n" +


### PR DESCRIPTION
Ran into the 5s timeout applying big patches in io.js, and thought it wouldn't hurt to bump up the default a bit, especially for slow connections.
