### PR TITLE
Allow plain URLs, without .git at the end

### DIFF
--- a/src/parse-repo.js
+++ b/src/parse-repo.js
@@ -1,5 +1,5 @@
 module.exports = function(remote, url) {
-    var repoPattern = /github.com(?:[:\/])([^\/]+)\/(.+?)\.git$/;
+    var repoPattern = /github.com(?:[:\/])([^\/]+)\/(.+?)(?:\.git)?$/;
     var result = repoPattern.exec(url);
     if (!result) {
         throw new Error("the remote '" + remote+ "' is not configured to a github repository");


### PR DESCRIPTION
GitHub allows cloning repos without the `.git` postfix, and that's my default approach. This currently breaks with `Error: the remote '[object Promise]' is not configured to a github repository`.
The error message handling probably needs fixing too.
